### PR TITLE
Fix Makefiles and dkms.conf to allow dkms to build against other than…

### DIFF
--- a/src/gpio-sb8xx/Makefile
+++ b/src/gpio-sb8xx/Makefile
@@ -1,5 +1,7 @@
 obj-m += gpio-sb8xx.o
+KVER ?= $(shell uname -r)
+KDIR ?= /lib/modules/$(KVER)/build
 all:
-	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) modules
+	$(MAKE) -C $(KDIR) M=$(PWD) modules
 clean:
-	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) clean
+	$(MAKE) -C $(KDIR) M=$(PWD) clean

--- a/src/gpio-sb8xx/dkms.conf
+++ b/src/gpio-sb8xx/dkms.conf
@@ -1,8 +1,9 @@
-MAKE="make -C ."
-CLEAN="make -C . clean"
+MAKE="make all KVER=${kernelver}"
+CLEAN="make clean"
 BUILT_MODULE_NAME=gpio-sb8xx
 BUILT_MODULE_LOCATION=.
 DEST_MODULE_LOCATION=/updates
 PACKAGE_NAME=gpio-sb8xx
 PACKAGE_VERSION=20180507
 REMAKE_INITRD=yes
+AUTOINSTALL=yes

--- a/src/i2c-piix4/Makefile
+++ b/src/i2c-piix4/Makefile
@@ -1,5 +1,7 @@
 obj-m += i2c-piix4.o
+KVER ?= $(shell uname -r)
+KDIR ?= /lib/modules/$(KVER)/build
 all:
-	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) modules
+	$(MAKE) -C $(KDIR) M=$(PWD) modules
 clean:
-	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) clean
+	$(MAKE) -C $(KDIR) M=$(PWD) clean

--- a/src/i2c-piix4/dkms.conf
+++ b/src/i2c-piix4/dkms.conf
@@ -1,8 +1,9 @@
-MAKE="make -C ."
-CLEAN="make -C . clean"
+MAKE="make all KVER=${kernelver}"
+CLEAN="make clean"
 BUILT_MODULE_NAME=i2c-piix4
 BUILT_MODULE_LOCATION=.
 DEST_MODULE_LOCATION=/updates
 PACKAGE_NAME=i2c-piix4
 PACKAGE_VERSION=20180509
 REMAKE_INITRD=yes
+AUTOINSTALL=yes

--- a/src/softpwm/Makefile
+++ b/src/softpwm/Makefile
@@ -1,5 +1,7 @@
 obj-m += softpwm.o
+KVER ?= $(shell uname -r)
+KDIR ?= /lib/modules/$(KVER)/build
 all:
-	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) modules
+	$(MAKE) -C $(KDIR) M=$(PWD) modules
 clean:
-	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) clean
+	$(MAKE) -C $(KDIR) M=$(PWD) clean

--- a/src/softpwm/dkms.conf
+++ b/src/softpwm/dkms.conf
@@ -1,8 +1,9 @@
-MAKE="make -C ."
-CLEAN="make -C . clean"
+MAKE="make all KVER=${kernelver}"
+CLEAN="make clean"
 BUILT_MODULE_NAME=softpwm
 BUILT_MODULE_LOCATION=.
 DEST_MODULE_LOCATION=/updates
 PACKAGE_NAME=softpwm
 PACKAGE_VERSION=20180507
 REMAKE_INITRD=yes
+AUTOINSTALL=yes


### PR DESCRIPTION
… running kernel version (e.g. when upgrading kernel)
Also make dkms automatically build modules for new kernels (AUTOINSTALL=yes)

reference issue #6 